### PR TITLE
Correct enforce_type vectors

### DIFF
--- a/R/enforce_types.R
+++ b/R/enforce_types.R
@@ -33,7 +33,7 @@ enforce_types <- function(x, suppress_na_introduced_warnings = TRUE) {
   if (suppress_na_introduced_warnings) {
     withCallingHandlers({
       x <- x %>%
-        dplyr::mutate_if(colnames(.) == "Robot", funs(. == 'Yes')) %>%
+        dplyr::mutate_if(colnames(.) == "Robot", dplyr::funs(. == 'Yes')) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_character, as.character) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_integer, as.integer) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_double, as.double) %>%
@@ -44,7 +44,7 @@ enforce_types <- function(x, suppress_na_introduced_warnings = TRUE) {
     )
   } else {
     x <- x %>%
-      dplyr::mutate_if(colnames(.) == "Robot", funs(. == 'Yes')) %>%
+      dplyr::mutate_if(colnames(.) == "Robot", dplyr::funs(. == 'Yes')) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_character, as.character) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_integer, as.integer) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_double, as.double) %>%

--- a/R/enforce_types.R
+++ b/R/enforce_types.R
@@ -15,24 +15,25 @@ enforce_types <- function(x, suppress_na_introduced_warnings = TRUE) {
                         "C14_Uncalibrated_Variation", "C14_Calibrated_From", "C14_Calibrated_To", "Type_Group", "Type", "Location_Bone_Room",
                         "Location_Bone", "Location_Powder_Room", "Location_Powder", "Sample", "Extract", "Library_Id", "Index_Set", 
                         "Quantification_pre-Indexing_total", "Quantification_post-Indexing_total", "Post-Indexing_elution_volume",
-                        "Capture", "Sequencing_Id", "Sequencer", "Setup", "Raw_Data", "Analysis", "Order")
-  coltypes_date <- c("Creation_Date", "Deleted_Date", "Experiment_Date", "Library", "Probe_Set")
+                        "Capture", "Sequencing_Id", "Sequencer", "Setup", "Raw_Data", "Analysis", "Order", "Probe_Set", "Library")
+  coltypes_date <- c("Creation_Date", "Deleted_Date", "Experiment_Date")
   coltypes_character <- c("Notes", "Tags", "Projects", "Contact_Person", "Position_on_Plate", "Location_Room", "Location", "Site_Id", 
                           "Full_Site_Id", "Name", "Locality", "Province", "Country", "Full_Individual_Id", "Owning_Institution", "Provenience",
                           "Archaeological_ID", "C14_Info", "C14_Id", "Ethics", "Individual", "Sample_Id", "Extract_Id", "Full_Extract_Id",
                           "Full_Library_Id", "P7_Barcode_Sequence", "P5_Barcode_Sequence", "P7_Index_Sequence", "P5_Index_Sequence", 
                           "P7_Index_Id", "P5_Index_Id", "External_Library_Id", "Position_on_Plate", "Capture_Id", "Full_Capture_Id",
-                          "Full_Sequencing_Id", "Run_Id", "Single_Stranded", "Analysis_Id", "Full_Analysis_Id", "Result_Directory") ## single stranded is yes/no, can't force as logical
+                          "Full_Sequencing_Id", "Run_Id", "Single_Stranded", "Analysis_Id", "Full_Analysis_Id", "Result_Directory")
   coltypes_logical <- c("Deleted", "Ethically_culturally_sensitive", "Robot", "Title") ## Skipping Analysis String 'Result' as should be numeric but includes mixed cells
   coltypes_double <- c("Latitude", "Longitude", "Sampled_Quantity", "Quantity_Sample", "Quantity_Lysate", "Sampled_Quantity", 
                        "Quantity_Extract", "Efficiency_Factor", "Weight_Lane_1-4", "Weight_Lane_1", "Weight_Lane_2", "Weight_Lane_3",
                        "Weight_Lane_4", "Weight_Lane_5", "Weight_Lane_6", "Weight_Lange_7", "Weight_Lane_8")
   
-  
-  # transform (invalid values become NA)
+  ## convert known Yes/No columns to logical because R doesn't recognise former, 
+  ## then enforce types for faster filtering. Invalid values become NA.
   if (suppress_na_introduced_warnings) {
     withCallingHandlers({
       x <- x %>%
+        dplyr::mutate_if(colnames(.) == "Robot", funs(. == 'Yes')) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_character, as.character) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_integer, as.integer) %>%
         dplyr::mutate_if(colnames(.) %in% coltypes_double, as.double) %>%
@@ -43,6 +44,7 @@ enforce_types <- function(x, suppress_na_introduced_warnings = TRUE) {
     )
   } else {
     x <- x %>%
+      dplyr::mutate_if(colnames(.) == "Robot", funs(. == 'Yes')) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_character, as.character) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_integer, as.integer) %>%
       dplyr::mutate_if(colnames(.) %in% coltypes_double, as.double) %>%


### PR DESCRIPTION
To fix https://github.com/sidora-tools/sidora.core/issues/8 

In my copy and paste repitition put a couple of non-date column headers into the date vector. Therefore `as.Date()` was reporting WTF mate, this ain't no date. This is fixed now.

As a bonus, I also added one more enforce type `mutate` function, to fix the 'Robot' column from Yes/No characters to actual logical T/F values.