### PR TITLE
changes in code and documentation to connect to the new pandora version at EVA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sidora.core
 Title: Basic Interface for PANDORA (MPI-SHH DAG)
-Version: 1.0.0
+Version: 2.0.0
 Authors@R: 
     c(person(given = "Clemens",
            family = "Schmid",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# sidora 2.0.0 - Briareus
+
+Applied some small but breaking changes to the way connections to the Pandora database server are established.
+
 # sidora 1.0.0 - Mnemosyne
 
 ## Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# sidora 2.0.0 - Briareus
+# sidora 2.0.0 - Phoebe
 
 Applied some small but breaking changes to the way connections to the Pandora database server are established.
 

--- a/R/utils_get_pandora_connection.R
+++ b/R/utils_get_pandora_connection.R
@@ -22,8 +22,9 @@ get_pandora_connection <- function(cred_file = ".credentials") {
   con <- DBI::dbConnect(
     RMariaDB::MariaDB(), 
     host = creds[1],
-    user = creds[2],
-    password = creds[3],
+    port = creds[2],
+    user = creds[3],
+    password = creds[4],
     db = "pandora"
   )
   

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Only one specific account has the right read permissions to access the Pandora d
 If all of that worked, then you can acccess Pandora with sidora.core. For example load a specific Pandora table:
 
 ```r
-library(magrittr)
 library(sidora.core)
 
 sites <- get_df("TAB_Site", con)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,17 @@ To use this package you have to follow these steps:
 1. Install the sidora.core package in R (see above)
 2. Create a `.credentials` file\*
 3. Connect to the institutes subnet via VPN (see the instructions in kbase)
-4. Establish an ssh tunnel to the pandora database server with for example `ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1` on the command line
-5. Run this in R to establish a connection to the database: `con <- sidora.core::get_pandora_connection("<path to your .credentials file>")`
+4. Establish an ssh tunnel to the pandora database server with
+
+    ```bash
+    ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1` on the command line
+    ```
+
+5. Run this in R to establish a connection to the database: 
+
+    ```r
+    con <- sidora.core::get_pandora_connection("<path to your .credentials file>")
+    ```
 
 \* The `.credentials` file must have the following content and structure:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # sidora.core
 
-Functions to access and download tables of the MPI-SHH DAG Pandora database using R. Serves as back-end for all sidora applications.
+Functions to access and download tables of the MPI-EVA DAG Pandora database using R. Serves as back-end for all sidora applications.
 
 ## Install
 
@@ -30,7 +30,6 @@ If you wish to set up a conda environment for using `sidora.core`, instructions 
 
 3. Once created, activate the environment
 
-
    ```bash
    conda activate sidora.core
    ```
@@ -42,22 +41,33 @@ If you wish to set up a conda environment for using `sidora.core`, instructions 
     remotes::install_github("sidora-tools/sidora.core")                             
     ``` 
 
-
-
 ## Quickstart guide
 
-Load the package and establish a database connection to Pandora. To do so you need the right `.credentials` file. Contact Stephan Schiffels, James Fellows Yates, or Clemens Schmid to obtain it. You also have to be in the institute's subnet.
+To use this package you have to follow these steps:
+
+1. Install the sidora.core package in R (see above)
+2. Create a `.credentials` file\*
+3. Connect to the institutes subnet via VPN (see the instructions in kbase)
+4. Establish an ssh tunnel to the pandora database server with for example `ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1` on the command line
+5. Run this in R to establish a connection to the database: `con <- sidora.core::get_pandora_connection("<path to your .credentials file>")`
+
+\* The `.credentials` file must have the following content and structure:
+
+```
+<host name of the database server>
+<port of the database server>
+<database username>
+<database password>
+```
+
+Only one specific account has the right read permissions to access the Pandora database directly. Please contact Stephan Schiffels, James Fellows Yates, or Clemens Schmid to obtain the relevant username and password.
+
+If all of that worked, then you can acccess Pandora with sidora.core. For example load a specific Pandora table:
 
 ```r
 library(magrittr)
 library(sidora.core)
 
-con <- get_pandora_connection(".credentials")
-```
-
-Load specific a specific Pandora table with:
-
-```r
 sites <- get_df("TAB_Site", con)
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use this package you have to follow these steps:
 4. Establish an ssh tunnel to the pandora database server with
 
     ```bash
-    ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1` on the command line
+    ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1`
     ```
 
 5. Run this in R to establish a connection to the database: 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ To use this package you have to follow these steps:
     ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1
     ```
 
+    > You must make a new tunnel each time you want to connect (e.g. after you log out or reboot your machine)
+
 5. Run this in R to establish a connection to the database: 
 
     ```r

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use this package you have to follow these steps:
 4. Establish an ssh tunnel to the pandora database server with
 
     ```bash
-    ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1`
+    ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1
     ```
 
 5. Run this in R to establish a connection to the database: 

--- a/man/sidora.core-package.Rd
+++ b/man/sidora.core-package.Rd
@@ -6,7 +6,7 @@
 \alias{sidora.core-package}
 \title{sidora.core: Basic Interface for PANDORA (MPI-SHH DAG)}
 \description{
-A basic interface to access data from the internal database PANDORA (MPI-SHH DAG).
+A basic interface to access data from the internal database PANDORA (MPI-EVA DAG).
 }
 \author{
 \strong{Maintainer}: Clemens Schmid \email{clemens@nevrome.de} (\href{https://orcid.org/0000-0003-3448-5715}{ORCID})
@@ -14,6 +14,11 @@ A basic interface to access data from the internal database PANDORA (MPI-SHH DAG
 Authors:
 \itemize{
   \item James Fellows Yates \email{jfy133@gmail.com} (\href{https://orcid.org/0000-0001-5585-6277}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item Stephan Schiffels (\href{https://orcid.org/0000-0002-1017-9150}{ORCID}) [contributor]
 }
 
 }

--- a/tests/testthat/helper-establish_database_connection.R
+++ b/tests/testthat/helper-establish_database_connection.R
@@ -10,8 +10,9 @@ if (!isTRUE(as.logical(Sys.getenv("CI")))) {
   con <- DBI::dbConnect(
     RMariaDB::MariaDB(), 
     host = creds[1],
-    user = creds[2],
-    password = creds[3],
+    port = creds[2],
+    user = creds[3],
+    password = creds[4],
     db = "pandora"
   )
 


### PR DESCRIPTION
So I think that might work. Probably even for pandora2eager on the cluster, if the .credentials file is adjusted accordingly.

Overall less convenient than in Jena, but probably more save :man_shrugging: 