### PR TITLE
Eva docs update

### DIFF
--- a/R/utils_get_pandora_connection.R
+++ b/R/utils_get_pandora_connection.R
@@ -13,8 +13,8 @@ get_pandora_connection <- function(cred_file = ".credentials") {
   if (!file.exists(cred_file)) {
     stop(paste(
       "[sidora.core] error: can't find .credentials file. Please create one ",
-      "containing three lines:", 
-      "the database host, the username, the password."
+      "containing four lines:", 
+      "the database host, port of the database server, the username, the password."
     ))
   }
   

--- a/R/utils_get_pandora_connection.R
+++ b/R/utils_get_pandora_connection.R
@@ -1,7 +1,8 @@
 #' Get the connection object for the Pandora DB 
 #' 
-#' @param cred_file character. Path to a credentials file containing three lines
-#' listing host, user and password, respectively
+#' @param cred_file character. Path to a credentials file containing four lines
+#' listing the database host, the port of the database server, user and password,
+#' respectively
 #'
 #' @return A Pandora DB connection object
 #' 

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ To use this package you have to follow these steps:
 1. Install the sidora.core package in R (see above)
 2. Create a `.credentials` file\*
 3. Connect to the institutes subnet via VPN (see the instructions in kbase)
-4. Establish an ssh tunnel to the pandora database server with
+4. If working locally, establish an ssh tunnel to the pandora database server with
 
     ```bash
     ssh -L 10001:pandora.eva.mpg.de:3306 <your username>@daghead1
     ```
 
-    > You must make a new tunnel each time you want to connect (e.g. after you log out or reboot your machine)
+    > You must make a new tunnel each time you want to connect (e.g. after you log out or reboot your machine).  
+    > ⚠️ This step is not necessary when working on the EVA servers directly.
 
 5. Run this in R to establish a connection to the database: 
 


### PR DESCRIPTION
Closes #45 

Changes: 
 - Update error message when `get_pandora_connection()` cannot find the credentials file to new credential file format.
 - README changed to explicitly state that an ssh tunnel is only needed when working locally.
