### PR TITLE
dplyr behaviour for appending suffixes upon join seems to have changed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
   bit64 (>= 4.0.0),
   DBI (>= 1.1.0),
   dbplyr (>= 2.1.0),
-  dplyr (>= 1.0.5),
+  dplyr (>= 1.1.0),
   hash (>= 2.2.6.1),
   magrittr (>= 2.0.0),
   purrr (>= 0.3.4),
@@ -42,4 +42,4 @@ Imports:
   utils
 Suggests: 
   testthat (>= 3.0.0)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/R/dataprep_get_data.R
+++ b/R/dataprep_get_data.R
@@ -181,7 +181,6 @@ access_prejoined_data <- function(tab, con){
     ) %>%
     # rename Id columns (after join for performance reasons!)  
     dplyr::rename(
-      Id = .data[["Id.x"]],
       String_Id = .data[["Id.y"]]
     )
   }


### PR DESCRIPTION
@aidaanva told me that she can not access `TAB_Analysis` any more.

```
analysis <- get_df("TAB_Analysis", con)

[sidora.core] loading analysis may take a while, please be patient.
Error in `.data[["Id.x"]]`:
! Column `Id.x` not found in `.data`.
```

I can reproduce this. My guess is, that this is caused by a change in dplyr 1.1.0. At least their changelog states ["Joins have been completely overhauled"](https://github.com/tidyverse/dplyr/releases/tag/v1.1.0), so that could be it.

I removed the offending and now apparently unnecessary line and made dplyr 1.1.0 mandatory for sidora.core. There are a number of more gentle solutions we could consider. Happy to think about it again tomorrow, but I quickly wanted to make you aware of the issue and provide and intermediate fix for Aida.