### PR TITLE
Fix for to_big_int

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,4 +42,4 @@ Imports:
   utils
 Suggests: 
   testthat (>= 3.0.0)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/dataprep_enforce_types.R
+++ b/R/dataprep_enforce_types.R
@@ -77,26 +77,32 @@ yesno_logical_to_logical <- function(x) {
 }
 
 to_big_int <- function(x) {
-  # step 1: get a clean character vector that encodes the numbers in a clean notation
-  cleaned_character_vector <- sapply(x, function(y) {
-    # no data
-    if (is.na(y) || y == "" || !grepl("(^[0-9]*$)|([0-9]E\\+)", y)) {
-      NA_character_
-    # scientific notation
-    } else if (grepl("\\+", y)) {
-      ss <- strsplit(y, "E\\+")[[1]]
-      multiplier <- sub("\\.|\\,", "", ss[1])
-      number_of_zeros <- as.integer(ss[2]) - nchar(multiplier) + 1
-      number_of_zeros <- ifelse(number_of_zeros < 0, 0, number_of_zeros)
-      paste0(
-        multiplier, 
-        paste(rep("0", number_of_zeros), collapse = "")
-      )
-    # everything is already alright
-    } else {
-      y
-    }
-  })
-  # step 2: transform cleaned character vector to integer64
-  bit64::as.integer64(cleaned_character_vector)
+  if (bit64::is.integer64(x)) {
+    x
+  } else if (is.character(x)) {
+    # step 1: get a clean character vector that encodes the numbers in a clean notation
+    cleaned_character_vector <- sapply(x, function(y) {
+      # no data
+      if (is.na(y) || y == "" || !grepl("(^[0-9]*$)|([0-9]E\\+)", y)) {
+        NA_character_
+      # scientific notation
+      } else if (grepl("\\+", y)) {
+        ss <- strsplit(y, "E\\+")[[1]]
+        multiplier <- sub("\\.|\\,", "", ss[1])
+        number_of_zeros <- as.integer(ss[2]) - nchar(multiplier) + 1
+        number_of_zeros <- ifelse(number_of_zeros < 0, 0, number_of_zeros)
+        paste0(
+          multiplier, 
+          paste(rep("0", number_of_zeros), collapse = "")
+        )
+      # everything is already alright
+      } else {
+        y
+      }
+    })
+    # step 2: transform cleaned character vector to integer64
+    bit64::as.integer64(cleaned_character_vector)
+  } else {
+    bit64::as.integer64(x)
+  }
 }

--- a/sidora.core.Rproj
+++ b/sidora.core.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: dec82a90-8c9b-41b8-8398-cf2c0cbd18cf
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Running

```r
con <- sidora.core::get_pandora_connection(".credentials")
raw <- sidora.core::get_df("TAB_Raw_Data", con)
```

currently fails for me with

```
Error in `map2()`:
ℹ In index: 7.
ℹ With name: raw_data.Demultiplexed_Reads.
Caused by error:
! protect(): protection stack overflow
```

I think something changed in the automatic type detection dbplyr (?) does for the big integer columns. It now seems to automatically detect the right type for these columns:

```r
raw_con <- sidora.core::get_con("TAB_Raw_Data", con)
class(dplyr::pull(raw_con, Demultiplexed_Reads))
```
```
[1] "integer64"
```

I suggest this change to avoid the error above, but also preserve the neat code we wrote for what I assume is the old behaviour of our dependencies. At least as long as we are not 100% sure if this works reliably.